### PR TITLE
ECAT: Move motor before ecmc since new dependency.

### DIFF
--- a/configure/MODULES_ECAT
+++ b/configure/MODULES_ECAT
@@ -1,6 +1,6 @@
+e3-motor
 e3-exprtk
 e3-ecmc
-e3-motor
 e3-EthercatMC
 e3-ecmccfg
 e3-BeckhoffADS


### PR DESCRIPTION
@ThomasFayESS. Not sure about the process of e3 related PR:s, or who should review them now when Han left. Anyway, I needed to move motor before ecmc since newest version of ecmc depends on motor.
Can you review and merge if you find it OK?!
Thanks!
