### PR TITLE
Fix order for LLRF modules

### DIFF
--- a/configure/MODULES_LLRF
+++ b/configure/MODULES_LLRF
@@ -1,7 +1,7 @@
 e3-loki
 e3-nds
+e3-scaling
 e3-sis8300drv
 e3-sis8300
 e3-sis8300llrfdrv
 e3-sis8300llrf
-e3-scaling


### PR DESCRIPTION
scaling should be compiled before sis8300